### PR TITLE
Changes in login and create ClientHome for a error of deploy in Vercel

### DIFF
--- a/src/app/components/ClientHome.tsx
+++ b/src/app/components/ClientHome.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import ContainerRegisterForm from '../sections/auth/register/containers/ContainerRegisterForm';
+import HomePage from './HomePage';
+import ContainerHome from '../sections/home/container/HomeContainer';
+
+export default function ClientHome() {
+  const searchParams = useSearchParams();
+  const [view, setView] = useState<'home' | 'register' | 'public-home'>('home');
+
+  useEffect(() => {
+    const urlView = searchParams.get('view');
+    if (urlView === 'register') {
+      setView('register');
+    } else if (urlView === 'explore') {
+      setView('public-home');
+    }
+  }, [searchParams]);
+
+  return (
+    <>
+      {view === 'home' && (
+        <HomePage
+          onRegisterClick={() => setView('register')}
+          onContinueClick={() => setView('public-home')}
+        />
+      )}
+
+      {view === 'register' && (
+        <ContainerRegisterForm onExploreClick={() => setView('public-home')} />
+      )}
+      
+      {view === 'public-home' && (
+        <ContainerHome onRegisterClick={() => setView('register')} />
+      )}
+    </>
+  );
+}
+// This component handles the client-side routing and rendering of different views
+// based on the URL parameters. It allows users to switch between the home page,
+// registration form, and a public home view. The use of `useSearchParams`
+// enables dynamic updates based on the query parameters in the URL, providing a
+// seamless user experience without full page reloads.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,20 +1,12 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import LeftPanel from '@/app/sections/auth/register/components/LeftPanel'
-import LoginForm from '@/app/sections/auth/login/components/LoginForm'
+import ContainerLoginForm from '@/app/sections/auth/login/container/ContainerLoginForm';
 
 export default function LoginPage() {
   const router = useRouter();
 
   return (
-    <div className="w-full justify-center flex min-h-screen bg-gray-50">
-      <div className="w-[40%] flex">
-        <LeftPanel onExploreClick={() => router.push('/?view=explore')} />
-      </div>
-      <div className="w-[60%] flex bg-slate-100 justify-center p-6">
-        <LoginForm />
-      </div>
-    </div>
+    <ContainerLoginForm onExploreClick={() => router.push('/?view=explore')} />
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,41 +1,16 @@
-'use client';
+import { Suspense } from 'react';
+import ClientHome from './components/ClientHome';
 
-import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
-import ContainerRegisterForm from './sections/auth/register/containers/ContainerRegisterForm';
-import HomePage from './components/HomePage';
-import ContainerHome from './sections/home/container/HomeContainer';
-
-export default function Page() {
-  const searchParams = useSearchParams();
-  const [view, setView] = useState<'home' | 'register' | 'public-home'>('home');
-
-  // Handle ?view=register or ?view=explore from URL
-  useEffect(() => {
-    const urlView = searchParams.get('view');
-    if (urlView === 'register') {
-      setView('register');
-    } else if (urlView === 'explore') {
-      setView('public-home');
-    }
-  }, [searchParams]);
-
+export default function HomePageWrapper() {
   return (
-    <>
-      {view === 'home' && (
-        <HomePage
-          onRegisterClick={() => setView('register')}
-          onContinueClick={() => setView('public-home')}
-        />
-      )}
-
-      {view === 'register' && (
-        <ContainerRegisterForm onExploreClick={() => setView('public-home')} />
-        
-      )}
-      {view === 'public-home' && (
-        <ContainerHome onRegisterClick={() => setView('register')} />
-      )}
-    </>
+    <Suspense fallback={<div className="p-8 text-center">Cargando vista...</div>}>
+      <ClientHome />
+    </Suspense>
   );
 }
+// This component serves as a wrapper for the ClientHome component, providing a
+// fallback loading state while the ClientHome component is being loaded. The
+// use of `Suspense` allows for a smoother user experience by displaying a loading
+// message while the main content is being prepared. This is particularly useful
+// for components that may take time to load, ensuring that users are aware that
+// content is being fetched or processed in the background.

--- a/src/app/sections/auth/login/components/LoginForm.tsx
+++ b/src/app/sections/auth/login/components/LoginForm.tsx
@@ -48,47 +48,51 @@ const LoginForm: React.FC = () => {
 };
 
   return (
-    <form onSubmit={handleLogin} className="w-full max-w-xl bg-white border-gray-500 items-center shadow-xl rounded-2xl p-8 flex flex-col justify-between min-h-[300px]">
-      <h2 className="text-xl font-semibold text-gray-700 text-center p-6">
-        Bienvenido a SkilLogin Academy
-      </h2>
+    <div className="flex flex-col h-full w-full max-w-xl mx-auto px-4">
+      <div className="bg-white border-blue-300 justify-center shadow-lg border-2 rounded-2xl w-full overflow-hidden">
+        <h3 className="text-xl font-semibold text-gray-700 text-center p-6">Inicio de sesión</h3>
 
-      {error && <p className="text-red-600 text-sm text-center">{error}</p>}
+        {/* Form with login data*/}
+        <form onSubmit={handleLogin} className="w-full max-w-xl bg-white border-gray-500 items-center shadow-xl rounded-2xl p-8 flex flex-col justify-between min-h-[300px]">
+         
+          {error && <p className="text-red-600 text-sm text-center">{error}</p>}
 
-      <div>
-        <label className="block text-sm mb-2 font-medium text-gray-700">Email</label>
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-          required
-        />
+          <div>
+            <label className="block text-sm mb-2 font-medium text-gray-700">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700">Password</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full p-2 border rounded"
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition"
+          >
+            Login
+          </button>
+
+          <p className="text-center text-sm text-gray-600">
+            ¿No tienes una cuenta?{' '}
+            <Link  href="/?view=register" className="text-blue-600 underline">Crear una cuenta </Link>
+          </p>
+        </form>
       </div>
-
-      <div>
-        <label className="block text-sm font-medium text-gray-700">Password</label>
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="w-full p-2 border rounded"
-          required
-        />
-      </div>
-
-      <button
-        type="submit"
-        className="w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition"
-      >
-        Login
-      </button>
-
-      <p className="text-center text-sm text-gray-600">
-        ¿No tienes una cuenta?{' '}
-        <Link  href="/?view=register" className="text-blue-600 underline">Crear una cuenta </Link>
-      </p>
-    </form>
+    </div>
   );
 };
 

--- a/src/app/sections/auth/login/container/ContainerLoginForm.tsx
+++ b/src/app/sections/auth/login/container/ContainerLoginForm.tsx
@@ -1,0 +1,31 @@
+// src/sections/auth/login/containers/ContainerLoginForm.tsx
+'use client';
+
+import LeftPanel from '@/app/sections/auth/register/components/LeftPanel';
+import LoginForm from '../components/LoginForm';
+
+interface ContainerLoginFormProps {
+  onExploreClick: () => void;
+}
+
+const ContainerLoginForm: React.FC<ContainerLoginFormProps> = ({ onExploreClick }) => {
+  return (
+    <div className="w-full flex justify-center items-center h-screen overflow-hidden">
+      <div className="w-full justify-center flex min-h-screen bg-gray-50">
+
+        {/* Left panel with explore prompt */}
+        <div className="w-[40%] flex">
+          <LeftPanel onExploreClick={onExploreClick} />
+        </div>
+
+        {/* Right panel with login form */}
+        <div className="w-[60%] flex bg-slate-100 justify-center p-6">
+          <LoginForm />
+        </div>
+        
+      </div>
+    </div>
+  );
+};
+
+export default ContainerLoginForm;


### PR DESCRIPTION
The error in vercel was fixed:
The /app/page.tsx is a Client Component ('use client') using useSearchParams(). That’s fine locally, but in Vercel's static optimization / prerendering, this conflicts with expected Server Component behavior for / routes.

Next.js expects /page.tsx to be server-rendered unless you explicitly turn it into a client-side-only app wrapped in <Suspense> from a Server Component.

Solution: Wrap Page in a Suspense Boundary
You need to make /app/page.tsx a dynamic client-rendered component that is rendered by a Server Component wrapper with <Suspense>.

Move the current logic to a new file: app/components/ClientHome.tsx
And the app/page.tsx as a Server Component wrapper.
 <Suspense fallback={<div className="p-8 text-center">Cargando vista...</div>}>
      <ClientHome />
    </Suspense>
